### PR TITLE
Make users <-> roles a hmt association

### DIFF
--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -1,0 +1,6 @@
+class Enrollment < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :role
+
+  validates :user, :role, :presence => true
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,5 @@
 class Role < ActiveRecord::Base
-  acts_as_authorization_role :join_table_name => :roles_users
+  acts_as_authorization_role :join_table_name => :enrollments
 
   attr_accessible :name
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   extend FriendlyId
 
-  acts_as_authorization_subject :association_name => :roles, :join_table_name => :roles_users
+  acts_as_authorization_subject :association_name => :roles, :join_table_name => :enrollments
   validates :github_uid, :username, :uniqueness => true, :presence => true
   validates :email, :format => { :with => /\A[^@]+@[^@]+\z/ }, :uniqueness => true, :allow_blank => true
 
@@ -11,6 +11,8 @@ class User < ActiveRecord::Base
   attr_accessible :gravatar_token, :email, :name, :site_url, :username, :github_uid
 
   has_many :posts
+  has_many :enrollments
+  has_many :roles, :through => :enrollments
 
   friendly_id :username, :use => :slugged
 

--- a/db/migrate/20120916100129_add_missing_indices_on_roles.rb
+++ b/db/migrate/20120916100129_add_missing_indices_on_roles.rb
@@ -1,0 +1,8 @@
+class AddMissingIndicesOnRoles < ActiveRecord::Migration
+  def change
+    add_index :roles, :name
+    add_index :roles, :authorizable_type
+    add_index :roles, :authorizable_id
+    add_index :roles, [ :name, :authorizable_type, :authorizable_id ], :unique => true
+  end
+end

--- a/db/migrate/20120916100420_add_missing_indices_on_roles_users.rb
+++ b/db/migrate/20120916100420_add_missing_indices_on_roles_users.rb
@@ -1,0 +1,7 @@
+class AddMissingIndicesOnRolesUsers < ActiveRecord::Migration
+  def change
+    add_index :roles_users, :user_id
+    add_index :roles_users, :role_id
+    add_index :roles_users, [ :user_id, :role_id ], :unique => true
+  end
+end

--- a/db/migrate/20120916100641_add_missing_fields_to_roles_users.rb
+++ b/db/migrate/20120916100641_add_missing_fields_to_roles_users.rb
@@ -1,0 +1,7 @@
+class AddMissingFieldsToRolesUsers < ActiveRecord::Migration
+  def change
+    add_column :roles_users, :created_at, :datetime
+    add_column :roles_users, :updated_at, :datetime
+    add_column :roles_users, :id,         :primary_key
+  end
+end

--- a/db/migrate/20120916100917_rename_roles_users_to_enrollments.rb
+++ b/db/migrate/20120916100917_rename_roles_users_to_enrollments.rb
@@ -1,0 +1,5 @@
+class RenameRolesUsersToEnrollments < ActiveRecord::Migration
+  def change
+    rename_table :roles_users, :enrollments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,18 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120615221524) do
+ActiveRecord::Schema.define(:version => 20120916100917) do
+
+  create_table "enrollments", :force => true do |t|
+    t.integer  "user_id"
+    t.integer  "role_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "enrollments", ["role_id"], :name => "index_roles_users_on_role_id"
+  add_index "enrollments", ["user_id", "role_id"], :name => "index_roles_users_on_user_id_and_role_id", :unique => true
+  add_index "enrollments", ["user_id"], :name => "index_roles_users_on_user_id"
 
   create_table "pages", :force => true do |t|
     t.string   "name",       :null => false
@@ -50,10 +61,10 @@ ActiveRecord::Schema.define(:version => 20120615221524) do
     t.datetime "updated_at",                      :null => false
   end
 
-  create_table "roles_users", :id => false, :force => true do |t|
-    t.integer "user_id"
-    t.integer "role_id"
-  end
+  add_index "roles", ["authorizable_id"], :name => "index_roles_on_authorizable_id"
+  add_index "roles", ["authorizable_type"], :name => "index_roles_on_authorizable_type"
+  add_index "roles", ["name", "authorizable_type", "authorizable_id"], :name => "index_roles_on_name_and_authorizable_type_and_authorizable_id", :unique => true
+  add_index "roles", ["name"], :name => "index_roles_on_name"
 
   create_table "taggings", :force => true do |t|
     t.integer  "tag_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,6 +98,14 @@ describe User do
       user = Factory.create( :user, :roles => 3.times.map{ Factory.create( :role ) } )
       user.roles.count.should eq(3)
     end
+
+    it 'creates an erollment per role' do
+      existing_user.roles.should be_empty
+      existing_user.has_role! :foo
+
+      existing_user.roles.length.should       eql(1)
+      existing_user.enrollments.length.should eql(1)
+    end
   end
 
   describe 'gravatar_url' do


### PR DESCRIPTION
`acl9` uses `has_and_belongs_to_many` for the many to many relationship,  which poses some problems:
- Join table can only have foreign keys
- There is no join model
- The lack of join model mean that we can't create scopes, or even make a relationship with more entities.

Fortunately since rails 3.0, associations are more powerful than in 2.3, and since the `acl9` code uses the association all the time, we just do the adjustment on the existing tables and create our own join model, we give `acl9` what it needs, but we override `acl9` association with our own.

The result is that all 3 points above get solved and our relationship between the models now looks like this:

users <-> enrollments <-> roles

And we can add any needed logic to enrollments in the future.

This commit also does some mayor performance improvements on roles (missing indices).
