### PR TITLE
add google analyticis account with gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'fakeweb'
 gem 'mail_form'
 gem 'pg'
 gem 'pg_power'
+gem 'google-analytics-rails'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     ffi (1.0.11)
     friendly_id (4.0.9)
     fssm (0.2.9)
+    google-analytics-rails (0.0.4)
     haml (3.1.4)
     haml-rails (0.3.4)
       actionpack (~> 3.0)
@@ -274,6 +275,7 @@ DEPENDENCIES
   factory_girl_rails
   fakeweb
   friendly_id
+  google-analytics-rails
   haml-rails
   jquery-rails
   json

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,7 @@
 !!!
 %html
   %head
+    = analytics_init if Rails.env.production?
     %title= t( 'head.title' )
     %link{ :rel => :icon, :type => 'image/png', :href => '/favicon.ico' }
     / [if lt IE 9]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,7 @@
 UserGroup::Application.configure do
+  # replace this with your tracker code
+  GA.tracker = "UA-39890570-1"
+
   # Settings specified here will take precedence over those in config/application.rb
 
   # Code is not reloaded between requests


### PR DESCRIPTION
I added [gem 'google-analytics-rails'](https://github.com/bgarret/google-analytics-rails) to add usergroup with obvious objective to Google Analytics. 

If the choice of this gem is wrong let me know to discuss the reasons. :worried:

Regards to all members of team. :v:

btw, you are free of give me feedback about the change and my style english write, will be very helpful :blush:  
